### PR TITLE
[Feature] Allows configuring single or two column layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The template will initialize your package with a sample call to the `acmart` fun
   // control max number of columns for authors and affiliation
   ncols-authors: 3,
   ncols-affiliations: 3,
+  // Page layout: "twocol" (default) or "singlecol".
+  layout: "twocol",
   conference: conference,
   doi: doi,
   copyright: "cc",

--- a/clean-acmart.typ
+++ b/clean-acmart.typ
@@ -115,7 +115,9 @@
     must be honored. For all other uses, contact the
     owner/author(s).
   ] else if mode == "cc" [
-    #image("cc-by.svg", width: 25%)
+    // Absolute width so the badge stays the same size regardless of column
+    // width (a column is ~3.3in in twocol but the full ~7in block in singlecol).
+    #image("cc-by.svg", width: 0.85in)
     This work is licensed under a
     #link("https://creativecommons.org/licenses/by/4.0/")[
       Creative Commons Attribution International 4.0

--- a/clean-acmart.typ
+++ b/clean-acmart.typ
@@ -277,6 +277,9 @@
   price: "$15.00",
   copyright: "cc",
 
+  // Page layout: "twocol" for two columns (default) or "singlecol" for a single column.
+  layout: "twocol",
+
   // Whether we are submitting as an anonymous version
   review: none,
 
@@ -294,6 +297,11 @@
   // The paper's content.
   body
 ) = {
+  assert(
+    layout in ("twocol", "singlecol"),
+    message: "layout must be either \"twocol\" or \"singlecol\", got: " + repr(layout),
+  )
+  let ncols = if layout == "singlecol" { 1 } else { 2 }
   set document(
     title: title, 
     author: if review == none { authors.map(a => to-string(a.name)) } else { () },
@@ -307,7 +315,7 @@
     paper: "us-letter",
     margin: (x: (8.5 - 7) / 2 * 1in, y: (11 - 9) / 2 * 1in),
     numbering: "1",
-    columns: 2,
+    columns: ncols,
   )
   set columns(gutter: 8mm)
   
@@ -389,7 +397,9 @@
   }
   
   show bibliography: it => {
-      colbreak(weak: true)
+      if layout == "twocol" {
+        colbreak(weak: true)
+      }
       it
   }
 
@@ -426,11 +436,13 @@
   }
   
   show bibliography: it => {
-    colbreak(weak: true)
+    if layout == "twocol" {
+      colbreak(weak: true)
+    }
     set text(size: .9em)
     it
   }
-  
+
   // Display the paper's contents.
   body
 }

--- a/template/main.typ
+++ b/template/main.typ
@@ -76,6 +76,8 @@
   // control max number of columns for authors and affiliation
   ncols-authors: 3,
   ncols-affiliations: 3,
+  // Page layout: "twocol" (default) or "singlecol".
+  layout: "twocol",
   conference: conference,
   doi: doi,
   copyright: "cc",


### PR DESCRIPTION
Hi,

Would like to request addition of this feature, which allows to specify singlecol or twocol for the layout. 

```{typst}
#show: acmart.with(
  title: title,
  authors: authors,
  affiliations: affiliations,
  // control max number of columns for authors and affiliation
  ncols-authors: 3,
  ncols-affiliations: 3,
  // Page layout: "twocol" (default) or "singlecol".
  layout: "twocol",
  conference: conference,
  doi: doi,
  copyright: "cc",
  // Set review to submission ID for the review process or to "none" for the final version.
  // review: [\#001],
)
```

<img width="890" height="476" alt="image" src="https://github.com/user-attachments/assets/d3cecff9-c151-4aee-b590-dcf8c563a44f" />
